### PR TITLE
Update Record Factory to use `sql_type` if `type` is missing

### DIFF
--- a/lib/mr/factory/record_factory.rb
+++ b/lib/mr/factory/record_factory.rb
@@ -45,7 +45,12 @@ module MR::Factory
     def column_args
       @columns ||= non_association_columns(@record_class)
       @columns.inject({}) do |a, column|
-        a.merge(column.name.to_s => MR::Factory.send(column.type))
+        column_type = column.type || column.sql_type
+        if !column_type.nil? && MR::Factory.respond_to?(column_type)
+          a.merge(column.name.to_s => MR::Factory.send(column_type))
+        else
+          a
+        end
       end
     end
 

--- a/test/unit/factory/read_model_factory_tests.rb
+++ b/test/unit/factory/read_model_factory_tests.rb
@@ -5,7 +5,10 @@ class MR::Factory::ReadModelFactory
 
   class UnitTests < Assert::Context
     desc "MR::Factory::ReadModelFactory"
-    subject{ MR::Factory::ReadModelFactory }
+    setup do
+      @factory_class = MR::Factory::ReadModelFactory
+    end
+    subject{ @factory_class }
 
     should "instance eval a block thats passed to it's `new`" do
       eval_scope = nil
@@ -22,7 +25,7 @@ class MR::Factory::ReadModelFactory
   class InstanceTests < UnitTests
     desc "instance"
     setup do
-      @factory = MR::Factory::ReadModelFactory.new(TestReadModel)
+      @factory = @factory_class.new(TestReadModel)
     end
     subject{ @factory }
 


### PR DESCRIPTION
This updates the Record Factory to use the ActiveRecord Column's
`sql_type` if `type` is missing/nil.  This makes MR more flexible in
which columns can be used.  If you are using a field in the database
that isn't support by ActiveRecord (i.e. `json` or `jsonb` for
ActiveRecord earlier than version 4), you can define a factory that
matches the `sql_type` and still use the factory.

This also updates the factory to avoid setting any fields that are not
supported.  This is the least suprising behavior as it does not force the
end user to define every columne type that is used, just those that are
important enough to generate data for.